### PR TITLE
Validate cmd line args, create and close imgs and files

### DIFF
--- a/cimple.c
+++ b/cimple.c
@@ -6,47 +6,36 @@
 
 #include "cimple.h"
 
-// define boleanos as enum
-typedef enum _bool { false, true } bool;
-
 void setup_header(char *header, long w, long h) {
   sprintf(header, "P6\n%04ld %04ld\n255\n", w, h);
 }
 
-long validate_number(char *nstr, long max, int base) {
+num_validation_codes validate_number(char *nstr, uint32_t *num, long max, int base) {
   char *buff_ptr = (char *)malloc(sizeof(char)*INT_BUFFER);
   char *endstr = buff_ptr;
-  bool valid = true;
-  long num;
+  num_validation_codes valid_code = ok;
 
   /* If nstr exceeds max lenght then is not valid */
   if ( strlen(nstr) > ceil(log10(max+1)) ) {
-    valid = false;
+    valid_code = bigger_than_max;
   } else {
     /* If does exceed max. try to convert */
-    num = strtol(nstr, &endstr, base);
+    *num = strtol(nstr, &endstr, base);
     if (*endstr != '\0')
-      valid = false;
-  }
-  /* If the number is longer than `max or not valid string explode */
-  if ( !valid ) {
-    fprintf(stderr,
-	    "Not valid argument. "
-	    "Enter integers less than %ld.\n", max);
-    /* ... bit first we free up memory used :3 */
-    free(buff_ptr);
-    exit(1);
+      valid_code = no_number_syntax;
   }
 
   free(buff_ptr);
-  return num;
+  return valid_code;
 }
   
-void fill_background(uint8_t *ppm_, uint32_t color, int w, int h) {
-  for (int i = 0; i < 3*w*h; i+=3) {
-    ppm_[i+0] = (color>>(8*0))&0xFF;
-    ppm_[i+1] = (color>>(8*1))&0xFF;
-    ppm_[i+2] = (color>>(8*2))&0xFF;
+void fill_background(ppm *img, uint32_t color) {
+  uint32_t w = img->width;
+  uint32_t h = img->height;
+  for (uint32_t i = 0; i < 3*w*h; i+=3) {
+    img->pixels[i+0] = (color>>(8*0))&0xFF;
+    img->pixels[i+1] = (color>>(8*1))&0xFF;
+    img->pixels[i+2] = (color>>(8*2))&0xFF;
   }
 }
 
@@ -97,4 +86,69 @@ void rectangle(ppm *img,
     point p1 = {origen.x+i, origen.y+h};
     line(img, *color, p0, p1);
   }
+}
+
+int validate_cmds(int ac,
+		  char *av[],
+		  uint32_t *color,
+		  uint32_t *w,
+		  uint32_t *h) {
+  int r = 0;
+  *w = 32;
+  *h = 32;
+  *color = 0xffff;
+  if (ac < 4) {
+    puts("Image default: 32x32. Background color yellow.");
+    return 0;
+  } else { /* Parse width of image */
+    if (validate_number(av[1], w, MAX_WIDTH, 10) < 0 ||
+	validate_number(av[2], h, MAX_HEIGHT, 10) < 0) {
+      *w = 32;
+      *h = 32;
+      r = -1;
+    }
+    if (validate_number(av[3], color, 0xFFFFFFFF, 16) < 0) {
+      *color = 0xffff;
+      r = -2;
+    }
+    printf("Image size: %dx%d.\n", *w, *h);
+  }
+  return r;
+}
+
+void free_ppm(ppm *img) {
+  free(img->header);
+  free(img->pixels);
+}
+
+int open_img(ppm *img, uint32_t w, uint32_t h) {
+  char *header = (char *)malloc(sizeof(char)*HEADER_LEN);
+  uint8_t *pixels = (uint8_t *)malloc(sizeof(uint8_t)*3*w*h);
+
+  if ( !header || !pixels ) {
+    return -1;
+  }
+
+  setup_header(header, w, h);
+
+  (*img).header=header;
+  (*img).pixels=pixels;
+  (*img).width=w;
+  (*img).height=h;
+
+  return 0;
+}
+
+int write_img_to_file(char *fname, ppm img) {
+  FILE *img_file;
+  uint32_t w = img.width;
+  uint32_t h = img.height;
+  if ((img_file = fopen(fname, "wb")) == NULL) {
+    fprintf(stderr, "Unable to open %s.", fname);
+    return -1;
+  }
+  fwrite(img.header, sizeof(char), HEADER_LEN, img_file);
+  fwrite(img.pixels, sizeof(uint8_t), 3*w*h, img_file);
+  fclose(img_file);
+  return 0;;
 }

--- a/cimple.h
+++ b/cimple.h
@@ -9,6 +9,12 @@
 #define HEADER_LEN 17
 #define INT_BUFFER 64 // buffer size to store strings representing integers
 
+// define boleanos as enum
+typedef enum _bool {
+  false = 0,
+  true  = 1
+} bool;
+
 typedef struct _point {
   float x;
   float y;
@@ -21,10 +27,24 @@ typedef struct _ppm {
   uint32_t height;
 } ppm;
 
+typedef enum _num_validation_codes {
+  ok = 0,
+  bigger_than_max = -1,
+  no_number_syntax = -2
+} num_validation_codes;
+
+//typedef enum _num_validation_codes num_validation_codes;
+
 void setup_header(char *header, long w, long h);
-long validate_number(char *nstr, long max, int base);
-void fill_background(uint8_t *ppm, uint32_t color, int w, int h);
+num_validation_codes validate_number(char *nstr, uint32_t *num, long max, int base);
+void fill_background(ppm *img, uint32_t color);
 void line(ppm *img, uint32_t color, point p0, point p1);
 void rectangle(ppm *img, uint32_t *color, point origen, uint32_t, uint32_t);
+
+int validate_cmds(int argc, char *argv[], uint32_t *color, uint32_t *w,
+                  uint32_t *h);
+int open_img(ppm *img, uint32_t w, uint32_t h);
+int write_img_to_file(char *fname, ppm img);
+void free_ppm(ppm *img);
 
 #endif

--- a/ppm_main.c
+++ b/ppm_main.c
@@ -2,62 +2,41 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
+//#include <math.h>
 #include "cimple.h"
 
 int main(int argc, char *argv[]) {
-  FILE *img_file;
   char fname[] = "imagen.ppm";
+  uint32_t width, height, bg_color;
+  ppm img;
 
-  long width, height;
-  uint32_t bg_color = 0x00FFFF; //yellow
-  if (argc < 4) {
-    /* Default image size of 32x32 pixels */
-    width  = 32;
-    height = 32;
-    puts("Image default: 32x32. Color bg yellow.");
-  } else { /* Parse width of image */
-    width  = validate_number(argv[1], MAX_WIDTH, 10);
-    height = validate_number(argv[2], MAX_HEIGHT, 10);
-    bg_color  = validate_number(argv[3], 0xFFFFFFFF, 16);
-    printf("Image size: %ldx%ld.\n", width, height);
-  }
-
-  if ((img_file = fopen(fname, "wb")) == NULL) {
-    fprintf(stderr, "Unable to open %s.", fname);
+  int ok_cmds = validate_cmds(argc, argv, &bg_color, &width, &height);
+  if (ok_cmds < 0) {
+    fprintf(stderr, "Invalid arguments.\n");
     exit(1);
   }
-  
-  char *header = (char *)malloc(sizeof(char)*HEADER_LEN);
-  uint8_t *data_buffer = (uint8_t *)malloc(sizeof(uint8_t)*3*width*height);
-  
-  setup_header(header, width, height);
 
-  ppm img = {.header=header,
-	     .pixels=data_buffer,
-	     .width=width,
-	     .height=height};
+  if ( open_img(&img, width, height) < 0 ) {
+    fprintf(stderr, "Unable to open imagen.\n");
+    exit(2);
+  }
+  
   point or = {.x=1, .y=1};
   
-  fill_background(data_buffer, bg_color, width, height);
+  fill_background(&img, bg_color);
   /*   255, 69, 0, // orange */
   /*   0, 0, 128, // navy blue */
-  point p0 = {(uint32_t)width/2, 1}, p1 = {(uint32_t)width/2, height};
+  point p0 = {width/2, 1}, p1 = {width/2, height};
   line(&img, 0x800000, p0, p1);
   p1.x = width; p1.y = height;
   line(&img, 0x800000, p0, p1);
   p0.x = 1; p0.y = 1;
   line(&img, 0xff00, p0, p1);
 
-  uint32_t red = 0xff;
-  rectangle(&img, &red, or, 5, 5);
+  uint32_t rect_color = 0x00;
+  rectangle(&img, &rect_color, or, 5, 9);
 
-  //g, r, b
-  fwrite(header, sizeof(char), HEADER_LEN, img_file);
-  fwrite(data_buffer, sizeof(uint8_t), 3*width*height, img_file);
-
-  free(header);
-  free(data_buffer);
-  fclose(img_file);
+  write_img_to_file(fname, img);
+  free_ppm(&img);
   return 0;
 }


### PR DESCRIPTION
1. Created `enum num_validation_codes` to `validate_numbers` function. The purpose is to avoid stopping program when a non valid number appears in cmd line arguments.
2. Modified `fill_background()` to use the new `struct ppm` .
3. boiler plate code to was added to `validate_cmd()` and `open_img()`.
4. Added `write_img_to_file()` to separate between pixels handling operations and writing them to a ppm file.
5. Added `free_ppm()` to free resources written used in header and pixels in `struct ppm`.